### PR TITLE
2.0

### DIFF
--- a/fsensor/build.gradle
+++ b/fsensor/build.gradle
@@ -14,8 +14,8 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 29
-        versionCode 8
-        versionName "1.2.3"
+        versionCode 9
+        versionName "2.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -40,5 +40,5 @@ dependencies {
     api files('libs/commons-math3-3.6.1.jar')
 
     api 'io.reactivex.rxjava2:rxandroid:2.1.0'
-    api 'io.reactivex.rxjava2:rxjava:2.2.2'
+    api 'io.reactivex.rxjava2:rxjava:2.2.15'
 }

--- a/fsensor/build.gradle
+++ b/fsensor/build.gradle
@@ -38,7 +38,4 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     api files('libs/commons-math3-3.6.1.jar')
-
-    api 'io.reactivex.rxjava2:rxandroid:2.1.0'
-    api 'io.reactivex.rxjava2:rxjava:2.2.15'
 }

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/averaging/MeanFilter.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/averaging/MeanFilter.java
@@ -37,7 +37,7 @@ public class MeanFilter extends AveragingFilter {
 
     private static final String tag = MeanFilter.class.getSimpleName();
 
-    private ArrayDeque<float[]> values;
+    private final ArrayDeque<float[]> values;
     private float[] output;
 
     /**

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/averaging/MedianFilter.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/averaging/MedianFilter.java
@@ -42,7 +42,7 @@ public class MedianFilter extends AveragingFilter {
     private static final String tag = MedianFilter.class
             .getSimpleName();
 
-    private ArrayDeque<float[]> values;
+    private final ArrayDeque<float[]> values;
     private float[] output;
 
 

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/OrientationFused.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/OrientationFused.java
@@ -36,9 +36,9 @@ public abstract class OrientationFused extends BaseFilter {
     // transfer functions (rotations from the gyroscope and
     // acceleration/magnetic, respectively).
     public float timeConstant;
-    protected Quaternion rotationVectorGyroscope;
+    protected Quaternion rotationVector;
     protected long timestamp = 0;
-    protected float[] output;
+    protected float[] output = new float[3];
 
     /**
      * Initialize a singleton instance.
@@ -49,7 +49,7 @@ public abstract class OrientationFused extends BaseFilter {
 
     public OrientationFused(float timeConstant) {
         this.timeConstant = timeConstant;
-        output = new float[3];
+
     }
 
     @Override
@@ -59,11 +59,11 @@ public abstract class OrientationFused extends BaseFilter {
 
     public void reset() {
         timestamp = 0;
-        rotationVectorGyroscope = null;
+        rotationVector = null;
     }
 
     public boolean isBaseOrientationSet() {
-        return rotationVectorGyroscope != null;
+        return rotationVector != null;
     }
 
     /**
@@ -87,6 +87,6 @@ public abstract class OrientationFused extends BaseFilter {
     public abstract float[] calculateFusedOrientation(float[] gyroscope, long timestamp, float[] acceleration, float[] magnetic);
 
     public void setBaseOrientation(Quaternion baseOrientation) {
-            rotationVectorGyroscope = baseOrientation;
+        rotationVector = baseOrientation;
     }
 }

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/complementary/OrientationFusedComplementary.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/complementary/OrientationFusedComplementary.java
@@ -120,23 +120,22 @@ public class OrientationFusedComplementary extends OrientationFused {
                 Quaternion rotationVectorAccelerationMagnetic = RotationUtil.getOrientationVectorFromAccelerationMagnetic(acceleration, magnetic);
 
                 if(rotationVectorAccelerationMagnetic != null) {
-                    rotationVectorGyroscope = RotationUtil.integrateGyroscopeRotation(rotationVectorGyroscope, gyroscope, dT, EPSILON);
+
+                    rotationVector  = RotationUtil.integrateGyroscopeRotation(rotationVector, gyroscope, dT, EPSILON);
 
                     // Apply the complementary fusedOrientation. // We multiply each rotation by their
                     // coefficients (scalar matrices)...
-                    Quaternion scaledRotationVectorAccelerationMagnetic = rotationVectorAccelerationMagnetic.multiply
-                            (oneMinusAlpha);
+                    Quaternion scaledRotationVectorAccelerationMagnetic = rotationVectorAccelerationMagnetic.multiply(oneMinusAlpha);
 
                     // Scale our quaternion for the gyroscope
-                    Quaternion scaledRotationVectorGyroscope = rotationVectorGyroscope.multiply(alpha);
+                    Quaternion scaledRotationVectorGyroscope = rotationVector.multiply(alpha);
 
-                    // ...and then add the two quaternions together.
+                    //...and then add the two quaternions together.
                     // output[0] = alpha * output[0] + (1 - alpha) * input[0];
-                    rotationVectorGyroscope = scaledRotationVectorGyroscope.add
-                            (scaledRotationVectorAccelerationMagnetic);
-                }
+                    Quaternion result = scaledRotationVectorGyroscope.add(scaledRotationVectorAccelerationMagnetic);
 
-                output = AngleUtils.getAngles(rotationVectorGyroscope.getQ0(), rotationVectorGyroscope.getQ1(), rotationVectorGyroscope.getQ2(), rotationVectorGyroscope.getQ3());
+                    output = AngleUtils.getAngles(result.getQ0(), result.getQ1(), result.getQ2(), result.getQ3());
+                }
             }
 
             this.timestamp = timestamp;

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/kalman/OrientationFusedKalman.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/kalman/OrientationFusedKalman.java
@@ -13,6 +13,7 @@ import com.kircherelectronics.fsensor.util.rotation.RotationUtil;
 import org.apache.commons.math3.complex.Quaternion;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /*
  * Copyright 2018, Kircher Electronics, LLC
@@ -61,12 +62,14 @@ public class OrientationFusedKalman extends OrientationFused {
     private static final String TAG = OrientationFusedComplementary.class.getSimpleName();
 
     private RotationKalmanFilter kalmanFilter;
-    private volatile boolean run;
+    private AtomicBoolean run;
     private volatile float dT;
     private volatile float[] output = new float[3];
     private Thread thread;
 
-    private volatile Quaternion rotationOrientation;
+    private volatile Quaternion rotationVectorAccelerationMagnetic;
+    private double[] vectorGyroscope = new double[4];
+    private double[] vectorAccelerationMagnetic = new double[4];
 
     public OrientationFusedKalman() {
         this(DEFAULT_TIME_CONSTANT);
@@ -74,24 +77,25 @@ public class OrientationFusedKalman extends OrientationFused {
 
     public OrientationFusedKalman(float timeConstant) {
         super(timeConstant);
+        run = new AtomicBoolean(false);
         kalmanFilter = new RotationKalmanFilter(new RotationProcessModel(), new RotationMeasurementModel());
     }
 
     public void startFusion() {
-        if (!run && thread == null) {
-            run = true;
+        if (!run.get() && thread == null) {
+            run.set(true);
 
             thread = new Thread(new Runnable() {
                 @Override
                 public void run() {
-                    while (run && !Thread.interrupted()) {
+                    while (run.get() && !Thread.interrupted()) {
 
-                        calculate();
+                        output = calculate();
 
                         try {
                             Thread.sleep(20);
                         } catch (InterruptedException e) {
-                            Log.e(TAG, "Kalman Thread Run", e);
+                            Log.e(TAG, "Kalman Thread", e);
                             Thread.currentThread().interrupt();
                         }
                     }
@@ -105,8 +109,8 @@ public class OrientationFusedKalman extends OrientationFused {
     }
 
     public void stopFusion() {
-        if (run && thread != null) {
-            run = false;
+        if (run.get() && thread != null) {
+            run.set(false);
             thread.interrupt();
             thread = null;
         }
@@ -133,21 +137,16 @@ public class OrientationFusedKalman extends OrientationFused {
      * @return An orientation vector -> @link SensorManager#getOrientation(float[], float[])}
      */
     private float[] calculate() {
-        if (rotationVectorGyroscope != null && rotationOrientation != null && dT != 0) {
+        if (rotationVector != null && rotationVectorAccelerationMagnetic != null && dT != 0) {
+            vectorGyroscope[0] = (float) rotationVector.getVectorPart()[0];
+            vectorGyroscope[1] = (float) rotationVector.getVectorPart()[1];
+            vectorGyroscope[2] = (float) rotationVector.getVectorPart()[2];
+            vectorGyroscope[3] = (float) rotationVector.getScalarPart();
 
-            double[] vectorGyroscope = new double[4];
-
-            vectorGyroscope[0] = (float) rotationVectorGyroscope.getVectorPart()[0];
-            vectorGyroscope[1] = (float) rotationVectorGyroscope.getVectorPart()[1];
-            vectorGyroscope[2] = (float) rotationVectorGyroscope.getVectorPart()[2];
-            vectorGyroscope[3] = (float) rotationVectorGyroscope.getScalarPart();
-
-            double[] vectorAccelerationMagnetic = new double[4];
-
-            vectorAccelerationMagnetic[0] = (float) rotationOrientation.getVectorPart()[0];
-            vectorAccelerationMagnetic[1] = (float) rotationOrientation.getVectorPart()[1];
-            vectorAccelerationMagnetic[2] = (float) rotationOrientation.getVectorPart()[2];
-            vectorAccelerationMagnetic[3] = (float) rotationOrientation.getScalarPart();
+            vectorAccelerationMagnetic[0] = (float) rotationVectorAccelerationMagnetic.getVectorPart()[0];
+            vectorAccelerationMagnetic[1] = (float) rotationVectorAccelerationMagnetic.getVectorPart()[1];
+            vectorAccelerationMagnetic[2] = (float) rotationVectorAccelerationMagnetic.getVectorPart()[2];
+            vectorAccelerationMagnetic[3] = (float) rotationVectorAccelerationMagnetic.getScalarPart();
 
             // Apply the Kalman fusedOrientation... Note that the prediction and correction
             // inputs could be swapped, but the fusedOrientation is much more stable in this
@@ -156,15 +155,12 @@ public class OrientationFusedKalman extends OrientationFused {
             kalmanFilter.correct(vectorAccelerationMagnetic);
 
             // rotation estimation.
-            rotationVectorGyroscope = new Quaternion(kalmanFilter.getStateEstimation()[3],
-                    Arrays.copyOfRange(kalmanFilter.getStateEstimation(), 0, 3));
+            Quaternion result = new Quaternion(kalmanFilter.getStateEstimation()[3], Arrays.copyOfRange(kalmanFilter.getStateEstimation(), 0, 3));
 
-            output = AngleUtils.getAngles(rotationVectorGyroscope.getQ0(), rotationVectorGyroscope.getQ1(), rotationVectorGyroscope.getQ2(), rotationVectorGyroscope.getQ3());
-
-            return output;
+            output = AngleUtils.getAngles(result.getQ0(), result.getQ1(), result.getQ2(), result.getQ3());
         }
 
-        return null;
+        return output;
     }
 
     /**
@@ -177,13 +173,12 @@ public class OrientationFusedKalman extends OrientationFused {
      * @return the fused orientation estimation.
      */
     public float[] calculateFusedOrientation(float[] gyroscope, long timestamp, float[] acceleration, float[] magnetic) {
-
         if(isBaseOrientationSet()) {
             if (this.timestamp != 0) {
                 dT = (timestamp - this.timestamp) * NS2S;
 
-                rotationOrientation = RotationUtil.getOrientationVectorFromAccelerationMagnetic(acceleration, magnetic);
-                rotationVectorGyroscope = RotationUtil.integrateGyroscopeRotation(rotationVectorGyroscope, gyroscope, dT, EPSILON);
+                rotationVectorAccelerationMagnetic = RotationUtil.getOrientationVectorFromAccelerationMagnetic(acceleration, magnetic);
+                rotationVector = RotationUtil.integrateGyroscopeRotation(rotationVector, gyroscope, dT, EPSILON);
             }
             this.timestamp = timestamp;
 

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/kalman/OrientationFusedKalman.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/kalman/OrientationFusedKalman.java
@@ -61,15 +61,15 @@ public class OrientationFusedKalman extends OrientationFused {
 
     private static final String TAG = OrientationFusedComplementary.class.getSimpleName();
 
-    private RotationKalmanFilter kalmanFilter;
-    private AtomicBoolean run;
+    private final RotationKalmanFilter kalmanFilter;
+    private final AtomicBoolean run;
     private volatile float dT;
     private volatile float[] output = new float[3];
     private Thread thread;
 
     private volatile Quaternion rotationVectorAccelerationMagnetic;
-    private double[] vectorGyroscope = new double[4];
-    private double[] vectorAccelerationMagnetic = new double[4];
+    private final double[] vectorGyroscope = new double[4];
+    private final double[] vectorAccelerationMagnetic = new double[4];
 
     public OrientationFusedKalman() {
         this(DEFAULT_TIME_CONSTANT);

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/kalman/filter/RotationMeasurementModel.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/filter/gyroscope/fusion/kalman/filter/RotationMeasurementModel.java
@@ -21,7 +21,7 @@ import org.apache.commons.math3.linear.RealMatrix;
  */
 public class RotationMeasurementModel implements MeasurementModel
 {
-	private double noiseCoefficient  = 0.001;
+	private final double noiseCoefficient  = 0.001;
 	
 	/**
 	 * The measurement matrix, used to associate the measurement vector to the

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/linearacceleration/LinearAcceleration.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/linearacceleration/LinearAcceleration.java
@@ -30,10 +30,9 @@ public abstract class LinearAcceleration {
 
     private static final String tag = LinearAcceleration.class.getSimpleName();
 
-    private float[] output = new float[]
-            {0, 0, 0};
+    private final float[] output = new float[]{0, 0, 0};
 
-    protected BaseFilter filter;
+    protected final BaseFilter filter;
 
     public LinearAcceleration(BaseFilter filter) {
         this.filter = filter;

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/observer/SensorSubject.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/observer/SensorSubject.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SensorSubject {
-    private List<SensorObserver> observers = new ArrayList<>();
+    private final List<SensorObserver> observers = new ArrayList<>();
 
     public interface SensorObserver {
         void onSensorChanged(float[] values);

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/observer/SensorSubject.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/observer/SensorSubject.java
@@ -1,0 +1,28 @@
+package com.kircherelectronics.fsensor.observer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SensorSubject {
+    private List<SensorObserver> observers = new ArrayList<>();
+
+    public interface SensorObserver {
+        void onSensorChanged(float[] values);
+    }
+
+    public void register(SensorObserver observer) {
+        if(!observers.contains(observer)) {
+            observers.add(observer);
+        }
+    }
+
+    public void unregister(SensorObserver observer) {
+        observers.remove(observer);
+    }
+
+    public void onNext(float[] values) {
+        for(int i = 0; i < observers.size(); i++) {
+            observers.get(i).onSensorChanged(values);
+        }
+    }
+}

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/FSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/FSensor.java
@@ -1,6 +1,6 @@
 package com.kircherelectronics.fsensor.sensor;
 
-import io.reactivex.subjects.PublishSubject;
+import com.kircherelectronics.fsensor.observer.SensorSubject;
 
 /*
  * Copyright 2018, Kircher Electronics, LLC
@@ -19,5 +19,9 @@ import io.reactivex.subjects.PublishSubject;
  */
 
 public interface FSensor {
-    PublishSubject<float[]> getPublishSubject();
+    void register(SensorSubject.SensorObserver sensorObserver);
+    void unregister(SensorSubject.SensorObserver sensorObserver);
+
+    void start();
+    void stop();
 }

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/AccelerationSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/AccelerationSensor.java
@@ -28,8 +28,8 @@ import com.kircherelectronics.fsensor.sensor.FSensor;
 public class AccelerationSensor implements FSensor {
     private static final String TAG = AccelerationSensor.class.getSimpleName();
 
-    private SensorManager sensorManager;
-    private SimpleSensorListener listener;
+    private final SensorManager sensorManager;
+    private final SimpleSensorListener listener;
     private float startTime = 0;
     private int count = 0;
 
@@ -38,7 +38,7 @@ public class AccelerationSensor implements FSensor {
 
     private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
 
-    private SensorSubject sensorSubject;
+    private final SensorSubject sensorSubject;
 
     public AccelerationSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/ComplementaryLinearAccelerationSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/ComplementaryLinearAccelerationSensor.java
@@ -32,8 +32,8 @@ import com.kircherelectronics.fsensor.util.rotation.RotationUtil;
 public class ComplementaryLinearAccelerationSensor implements FSensor {
     private static final String TAG = ComplementaryLinearAccelerationSensor.class.getSimpleName();
 
-    private SensorManager sensorManager;
-    private SimpleSensorListener listener;
+    private final SensorManager sensorManager;
+    private final SimpleSensorListener listener;
     private float startTime = 0;
     private int count = 0;
 
@@ -49,7 +49,7 @@ public class ComplementaryLinearAccelerationSensor implements FSensor {
     private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
     private int sensorType = Sensor.TYPE_GYROSCOPE;
 
-    private SensorSubject sensorSubject;
+    private final SensorSubject sensorSubject;
 
     public ComplementaryLinearAccelerationSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
@@ -127,6 +127,7 @@ public class ComplementaryLinearAccelerationSensor implements FSensor {
         stop();
         magnetic = new float[3];
         acceleration = new float[3];
+        rawAcceleration = new float[3];
         rotation = new float[3];
         output = new float[4];
         listener.reset();

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/KalmanLinearAccelerationSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/KalmanLinearAccelerationSensor.java
@@ -32,8 +32,8 @@ import com.kircherelectronics.fsensor.util.rotation.RotationUtil;
 public class KalmanLinearAccelerationSensor implements FSensor {
     private static final String TAG = KalmanLinearAccelerationSensor.class.getSimpleName();
 
-    private SensorManager sensorManager;
-    private SimpleSensorListener listener;
+    private final SensorManager sensorManager;
+    private final SimpleSensorListener listener;
     private float startTime = 0;
     private int count = 0;
 
@@ -49,7 +49,7 @@ public class KalmanLinearAccelerationSensor implements FSensor {
     private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
     private int sensorType = Sensor.TYPE_GYROSCOPE;
 
-    private SensorSubject sensorSubject;
+    private final SensorSubject sensorSubject;
 
     public KalmanLinearAccelerationSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
@@ -117,6 +117,7 @@ public class KalmanLinearAccelerationSensor implements FSensor {
         stop();
         magnetic = new float[3];
         acceleration = new float[3];
+        rawAcceleration = new float[3];
         rotation = new float[3];
         output = new float[4];
         listener.reset();

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/KalmanLinearAccelerationSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/KalmanLinearAccelerationSensor.java
@@ -9,10 +9,9 @@ import android.hardware.SensorManager;
 import com.kircherelectronics.fsensor.filter.gyroscope.fusion.kalman.OrientationFusedKalman;
 import com.kircherelectronics.fsensor.linearacceleration.LinearAcceleration;
 import com.kircherelectronics.fsensor.linearacceleration.LinearAccelerationFusion;
+import com.kircherelectronics.fsensor.observer.SensorSubject;
 import com.kircherelectronics.fsensor.sensor.FSensor;
 import com.kircherelectronics.fsensor.util.rotation.RotationUtil;
-
-import io.reactivex.subjects.PublishSubject;
 
 /*
  * Copyright 2018, Kircher Electronics, LLC
@@ -38,9 +37,6 @@ public class KalmanLinearAccelerationSensor implements FSensor {
     private float startTime = 0;
     private int count = 0;
 
-    private boolean hasRotation = false;
-    private boolean hasMagnetic = false;
-
     private float[] magnetic = new float[3];
     private float[] rawAcceleration = new float[3];
     private float[] rotation = new float[3];
@@ -50,47 +46,81 @@ public class KalmanLinearAccelerationSensor implements FSensor {
     private LinearAcceleration linearAccelerationFilterKalman;
     private OrientationFusedKalman orientationFusionKalman;
 
-    private int sensorFrequency = SensorManager.SENSOR_DELAY_FASTEST;
+    private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
+    private int sensorType = Sensor.TYPE_GYROSCOPE;
 
-    private PublishSubject<float[]> publishSubject;
+    private SensorSubject sensorSubject;
 
     public KalmanLinearAccelerationSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
         this.listener = new SimpleSensorListener();
-        this.publishSubject = PublishSubject.create();
+        this.sensorSubject = new SensorSubject();
         initializeFSensorFusions();
     }
 
-    @Override
-    public PublishSubject<float[]> getPublishSubject() {
-        return publishSubject;
-    }
 
-    public void onStart() {
+    /**
+     * Start the sensor.
+     */
+    @Override
+    public void start() {
         startTime = 0;
         count = 0;
-        registerSensors(sensorFrequency);
+        registerSensors(sensorDelay);
         orientationFusionKalman.startFusion();
     }
 
-    public void onStop() {
+    /**
+     * Stop the sensor.
+     */
+    @Override
+    public void stop() {
         orientationFusionKalman.stopFusion();
         unregisterSensors();
     }
 
-    public void setSensorFrequency(int sensorFrequency) {
-        this.sensorFrequency = sensorFrequency;
+    @Override
+    public void register(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.register(sensorObserver);
+    }
+
+    @Override
+    public void unregister(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.unregister(sensorObserver);
+    }
+
+    /**
+     * Set the gyroscope sensor type.
+     * @param sensorType must be Sensor.TYPE_GYROSCOPE or Sensor.TYPE_GYROSCOPE_UNCALIBRATED
+     */
+    public void setSensorType(int sensorType) {
+        if(sensorType != Sensor.TYPE_GYROSCOPE && sensorType != Sensor.TYPE_GYROSCOPE_UNCALIBRATED) {
+            throw new IllegalStateException("Sensor Type must be Sensor.TYPE_GYROSCOPE or Sensor.TYPE_GYROSCOPE_UNCALIBRATED");
+        }
+
+        this.sensorType = sensorType;
+    }
+
+    /**
+     * Set the sensor frequency.
+     * @param sensorDelay Must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or SensorManager.SENSOR_DELAY_UI
+     */
+    public void setSensorDelay(int sensorDelay) {
+        if(sensorDelay != SensorManager.SENSOR_DELAY_FASTEST && sensorDelay != SensorManager.SENSOR_DELAY_GAME && sensorDelay != SensorManager.SENSOR_DELAY_NORMAL && sensorDelay != SensorManager.SENSOR_DELAY_UI) {
+            throw new IllegalStateException("Sensor Frequency must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or " +
+                    "SensorManager.SENSOR_DELAY_UI");
+        }
+        this.sensorDelay = sensorDelay;
     }
 
     public void reset() {
-        onStop();
+        stop();
         magnetic = new float[3];
         acceleration = new float[3];
         rotation = new float[3];
         output = new float[4];
-        hasRotation = false;
-        hasMagnetic = false;
-        onStart();
+        listener.reset();
+        start();
     }
 
     private float calculateSensorFrequency() {
@@ -147,7 +177,7 @@ public class KalmanLinearAccelerationSensor implements FSensor {
 
         // Register for sensor updates.
         sensorManager.registerListener(listener,
-                sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE_UNCALIBRATED),
+                sensorManager.getDefaultSensor(sensorType),
                 sensorDelay);
 
     }
@@ -159,10 +189,18 @@ public class KalmanLinearAccelerationSensor implements FSensor {
     private void setOutput(float[] value) {
         System.arraycopy(value, 0, output, 0, value.length);
         output[3] = calculateSensorFrequency();
-        publishSubject.onNext(output);
+        sensorSubject.onNext(output);
     }
 
     private class SimpleSensorListener implements SensorEventListener {
+
+        private boolean hasRotation = false;
+        private boolean hasMagnetic = false;
+
+        private void reset() {
+            hasRotation = false;
+            hasMagnetic = false;
+        }
 
         @Override
         public void onSensorChanged(SensorEvent event) {
@@ -181,7 +219,7 @@ public class KalmanLinearAccelerationSensor implements FSensor {
             } else if (event.sensor.getType() == Sensor.TYPE_MAGNETIC_FIELD) {
                 processMagnetic(event.values);
                 hasMagnetic = true;
-            } else if (event.sensor.getType() == Sensor.TYPE_GYROSCOPE_UNCALIBRATED) {
+            } else if (event.sensor.getType() == sensorType) {
                 processRotation(event.values);
                 hasRotation = true;
             }

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/LinearAccelerationSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/LinearAccelerationSensor.java
@@ -28,8 +28,8 @@ import com.kircherelectronics.fsensor.sensor.FSensor;
 public class LinearAccelerationSensor implements FSensor {
     private static final String TAG = LinearAccelerationSensor.class.getSimpleName();
 
-    private SensorManager sensorManager;
-    private SimpleSensorListener listener;
+    private final SensorManager sensorManager;
+    private final SimpleSensorListener listener;
     private float startTime = 0;
     private int count = 0;
 
@@ -38,7 +38,7 @@ public class LinearAccelerationSensor implements FSensor {
 
     private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
 
-    private SensorSubject sensorSubject;
+    private final SensorSubject sensorSubject;
 
     public LinearAccelerationSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/LinearAccelerationSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/LinearAccelerationSensor.java
@@ -6,9 +6,8 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 
+import com.kircherelectronics.fsensor.observer.SensorSubject;
 import com.kircherelectronics.fsensor.sensor.FSensor;
-
-import io.reactivex.subjects.PublishSubject;
 
 /*
  * Copyright 2018, Kircher Electronics, LLC
@@ -37,41 +36,62 @@ public class LinearAccelerationSensor implements FSensor {
     private float[] acceleration = new float[3];
     private float[] output = new float[4];
 
-    private int sensorFrequency = SensorManager.SENSOR_DELAY_FASTEST;
+    private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
 
-    private PublishSubject<float[]> publishSubject;
+    private SensorSubject sensorSubject;
 
     public LinearAccelerationSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
         this.listener = new SimpleSensorListener();
-        this.publishSubject = PublishSubject.create();
+        this.sensorSubject = new SensorSubject();
     }
 
+    /**
+     * Start the sensor.
+     */
     @Override
-    public PublishSubject<float[]> getPublishSubject() {
-        return publishSubject;
-    }
-
-    public void onStart() {
+    public void start() {
         startTime = 0;
         count = 0;
 
-        registerSensors(sensorFrequency);
+        registerSensors(sensorDelay);
     }
 
-    public void onStop() {
+    /**
+     * Stop the sensor.
+     */
+    @Override
+    public void stop() {
         unregisterSensors();
     }
 
-    public void setSensorFrequency(int sensorFrequency) {
-        this.sensorFrequency = sensorFrequency;
+    @Override
+    public void register(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.register(sensorObserver);
+    }
+
+    @Override
+    public void unregister(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.unregister(sensorObserver);
+    }
+
+    /**
+     * Set the sensor frequency.
+     * @param sensorDelay Must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or SensorManager.SENSOR_DELAY_UI
+     */
+    public void setSensorDelay(int sensorDelay) {
+        if(sensorDelay != SensorManager.SENSOR_DELAY_FASTEST && sensorDelay != SensorManager.SENSOR_DELAY_GAME && sensorDelay != SensorManager.SENSOR_DELAY_NORMAL && sensorDelay != SensorManager.SENSOR_DELAY_UI) {
+            throw new IllegalStateException("Sensor Frequency must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or " +
+                    "SensorManager.SENSOR_DELAY_UI");
+        }
+        this.sensorDelay = sensorDelay;
     }
 
     public void reset() {
-        onStop();
+        stop();
         acceleration = new float[3];
         output = new float[4];
-        onStart();
+        start();
     }
 
     private float calculateSensorFrequency() {
@@ -109,7 +129,7 @@ public class LinearAccelerationSensor implements FSensor {
     private void setOutput(float[] value) {
         System.arraycopy(value, 0, output, 0, value.length);
         output[3] = calculateSensorFrequency();
-        publishSubject.onNext(output);
+        sensorSubject.onNext(output);
     }
 
     private class SimpleSensorListener implements SensorEventListener {

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/LowPassLinearAccelerationSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/LowPassLinearAccelerationSensor.java
@@ -31,8 +31,8 @@ import com.kircherelectronics.fsensor.sensor.FSensor;
 public class LowPassLinearAccelerationSensor implements FSensor {
     private static final String TAG = LowPassLinearAccelerationSensor.class.getSimpleName();
 
-    private SensorManager sensorManager;
-    private SimpleSensorListener listener;
+    private final SensorManager sensorManager;
+    private final SimpleSensorListener listener;
     private float startTime = 0;
     private int count = 0;
 
@@ -46,7 +46,7 @@ public class LowPassLinearAccelerationSensor implements FSensor {
 
     private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
 
-    private SensorSubject sensorSubject;
+    private final SensorSubject sensorSubject;
 
     public LowPassLinearAccelerationSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
@@ -103,6 +103,7 @@ public class LowPassLinearAccelerationSensor implements FSensor {
     public void reset() {
         stop();
         acceleration = new float[3];
+        rawAcceleration = new float[3];
         output = new float[4];
         start();
     }

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/LowPassLinearAccelerationSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/acceleration/LowPassLinearAccelerationSensor.java
@@ -9,9 +9,8 @@ import android.hardware.SensorManager;
 import com.kircherelectronics.fsensor.filter.averaging.LowPassFilter;
 import com.kircherelectronics.fsensor.linearacceleration.LinearAcceleration;
 import com.kircherelectronics.fsensor.linearacceleration.LinearAccelerationAveraging;
+import com.kircherelectronics.fsensor.observer.SensorSubject;
 import com.kircherelectronics.fsensor.sensor.FSensor;
-
-import io.reactivex.subjects.PublishSubject;
 
 /*
  * Copyright 2018, Kircher Electronics, LLC
@@ -45,35 +44,56 @@ public class LowPassLinearAccelerationSensor implements FSensor {
 
     private LowPassFilter lpfGravity;
 
-    private int sensorFrequency = SensorManager.SENSOR_DELAY_FASTEST;
+    private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
 
-    private PublishSubject<float[]> publishSubject;
+    private SensorSubject sensorSubject;
 
     public LowPassLinearAccelerationSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
         this.listener = new SimpleSensorListener();
-        this.publishSubject = PublishSubject.create();
+        this.sensorSubject = new SensorSubject();
         initializeFSensorFusions();
     }
 
+    /**
+     * Stop the sensor.
+     */
     @Override
-    public PublishSubject<float[]> getPublishSubject() {
-        return publishSubject;
-    }
-
-    public void onStart() {
+    public void start() {
         startTime = 0;
         count = 0;
 
-        registerSensors(sensorFrequency);
+        registerSensors(sensorDelay);
     }
 
-    public void onStop() {
+    /**
+     * Stop the sensor.
+     */
+    @Override
+    public void stop() {
         unregisterSensors();
     }
 
-    public void setSensorFrequency(int sensorFrequency) {
-        this.sensorFrequency = sensorFrequency;
+    @Override
+    public void register(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.register(sensorObserver);
+    }
+
+    @Override
+    public void unregister(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.unregister(sensorObserver);
+    }
+
+    /**
+     * Set the sensor frequency.
+     * @param sensorDelay Must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or SensorManager.SENSOR_DELAY_UI
+     */
+    public void setSensorDelay(int sensorDelay) {
+        if(sensorDelay != SensorManager.SENSOR_DELAY_FASTEST && sensorDelay != SensorManager.SENSOR_DELAY_GAME && sensorDelay != SensorManager.SENSOR_DELAY_NORMAL && sensorDelay != SensorManager.SENSOR_DELAY_UI) {
+            throw new IllegalStateException("Sensor Frequency must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or " +
+                    "SensorManager.SENSOR_DELAY_UI");
+        }
+        this.sensorDelay = sensorDelay;
     }
 
     public void setFSensorLpfLinearAccelerationTimeConstant(float timeConstant) {
@@ -81,10 +101,10 @@ public class LowPassLinearAccelerationSensor implements FSensor {
     }
 
     public void reset() {
-        onStop();
+        stop();
         acceleration = new float[3];
         output = new float[4];
-        onStart();
+        start();
     }
 
     private float calculateSensorFrequency() {
@@ -143,7 +163,7 @@ public class LowPassLinearAccelerationSensor implements FSensor {
     private void setOutput(float[] value) {
         System.arraycopy(value, 0, output, 0, value.length);
         output[3] = calculateSensorFrequency();
-        publishSubject.onNext(output);
+        sensorSubject.onNext(output);
     }
 
     private class SimpleSensorListener implements SensorEventListener {

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/ComplementaryGyroscopeSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/ComplementaryGyroscopeSensor.java
@@ -7,10 +7,9 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 
 import com.kircherelectronics.fsensor.filter.gyroscope.fusion.complementary.OrientationFusedComplementary;
+import com.kircherelectronics.fsensor.observer.SensorSubject;
 import com.kircherelectronics.fsensor.sensor.FSensor;
 import com.kircherelectronics.fsensor.util.rotation.RotationUtil;
-
-import io.reactivex.subjects.PublishSubject;
 
 /*
  * Copyright 2018, Kircher Electronics, LLC
@@ -36,9 +35,6 @@ public class ComplementaryGyroscopeSensor implements FSensor {
     private float startTime = 0;
     private int count = 0;
 
-    private boolean hasAcceleration = false;
-    private boolean hasMagnetic = false;
-
     private float[] magnetic = new float[3];
     private float[] acceleration = new float[3];
     private float[] rotation = new float[3];
@@ -46,34 +42,68 @@ public class ComplementaryGyroscopeSensor implements FSensor {
 
     private OrientationFusedComplementary orientationFusionComplimentary;
 
-    private int sensorFrequency = SensorManager.SENSOR_DELAY_FASTEST;
+    private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
+    private int sensorType = Sensor.TYPE_GYROSCOPE;
 
-    private PublishSubject<float[]> publishSubject;
+    private SensorSubject sensorSubject;
 
     public ComplementaryGyroscopeSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
         this.listener = new SimpleSensorListener();
-        this.publishSubject = PublishSubject.create();
+        this.sensorSubject = new SensorSubject();
         initializeFSensorFusions();
     }
 
+    /**
+     * Start the sensor.
+     */
     @Override
-    public PublishSubject<float[]> getPublishSubject() {
-        return publishSubject;
-    }
-
-    public void onStart() {
+    public void start() {
         startTime = 0;
         count = 0;
-        registerSensors(sensorFrequency);
+        registerSensors(sensorDelay);
     }
 
-    public void onStop() {
+    /**
+     * Stop the sensor.
+     */
+    @Override
+    public void stop() {
         unregisterSensors();
     }
 
-    public void setSensorFrequency(int sensorFrequency) {
-        this.sensorFrequency = sensorFrequency;
+    @Override
+    public void register(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.register(sensorObserver);
+    }
+
+    @Override
+    public void unregister(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.unregister(sensorObserver);
+    }
+
+    /**
+     * Set the gyroscope sensor type.
+     * @param sensorType must be Sensor.TYPE_GYROSCOPE or Sensor.TYPE_GYROSCOPE_UNCALIBRATED
+     */
+    public void setSensorType(int sensorType) {
+        if(sensorType != Sensor.TYPE_GYROSCOPE && sensorType != Sensor.TYPE_GYROSCOPE_UNCALIBRATED) {
+            throw new IllegalStateException("Sensor Type must be Sensor.TYPE_GYROSCOPE or Sensor.TYPE_GYROSCOPE_UNCALIBRATED");
+        }
+
+        this.sensorType = sensorType;
+    }
+
+    /**
+     * Set the sensor frequency.
+     * @param sensorDelay Must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or SensorManager.SENSOR_DELAY_UI
+     */
+    public void setSensorDelay(int sensorDelay) {
+        if(sensorDelay != SensorManager.SENSOR_DELAY_FASTEST && sensorDelay != SensorManager.SENSOR_DELAY_GAME && sensorDelay != SensorManager.SENSOR_DELAY_NORMAL && sensorDelay != SensorManager.SENSOR_DELAY_UI) {
+            throw new IllegalStateException("Sensor Frequency must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or " +
+                    "SensorManager.SENSOR_DELAY_UI");
+        }
+        this.sensorDelay = sensorDelay;
     }
 
     public void setFSensorComplimentaryTimeConstant(float timeConstant) {
@@ -81,14 +111,13 @@ public class ComplementaryGyroscopeSensor implements FSensor {
     }
 
     public void reset() {
-        onStop();
+        stop();
         magnetic = new float[3];
         acceleration = new float[3];
         rotation = new float[3];
         output = new float[4];
-        hasAcceleration = false;
-        hasMagnetic = false;
-        onStart();
+        listener.reset();
+        start();
     }
 
     private float calculateSensorFrequency() {
@@ -140,7 +169,7 @@ public class ComplementaryGyroscopeSensor implements FSensor {
 
         // Register for sensor updates.
         sensorManager.registerListener(listener,
-                sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE_UNCALIBRATED),
+                sensorManager.getDefaultSensor(sensorType),
                 sensorDelay);
 
     }
@@ -152,28 +181,28 @@ public class ComplementaryGyroscopeSensor implements FSensor {
     private void setValue(float[] value) {
         System.arraycopy(value, 0, output, 0, value.length);
         output[3] = calculateSensorFrequency();
-        publishSubject.onNext(output);
+        sensorSubject.onNext(output);
     }
 
     private class SimpleSensorListener implements SensorEventListener {
 
-        private int sensorEventThreshold = 100;
-        private int numAccelerationEvents = 0;
-        private int numMagneticEvents = 0;
+        private boolean hasAcceleration = false;
+        private boolean hasMagnetic = false;
+
+        private void reset() {
+            hasAcceleration = false;
+            hasMagnetic = false;
+        }
 
         @Override
         public void onSensorChanged(SensorEvent event) {
             if (event.sensor.getType() == Sensor.TYPE_ACCELEROMETER) {
                 processAcceleration(event.values);
-                if(numAccelerationEvents++ > sensorEventThreshold) {
-                    hasAcceleration = true;
-                }
+                hasAcceleration = true;
             } else if (event.sensor.getType() == Sensor.TYPE_MAGNETIC_FIELD) {
                 processMagnetic(event.values);
-                if(numMagneticEvents ++ > sensorEventThreshold) {
-                    hasMagnetic = true;
-                }
-            } else if (event.sensor.getType() == Sensor.TYPE_GYROSCOPE_UNCALIBRATED) {
+                hasMagnetic = true;
+            } else if (event.sensor.getType() == sensorType) {
                 processRotation(event.values);
                 if (!orientationFusionComplimentary.isBaseOrientationSet()) {
                     if (hasAcceleration && hasMagnetic) {

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/ComplementaryGyroscopeSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/ComplementaryGyroscopeSensor.java
@@ -30,8 +30,8 @@ import com.kircherelectronics.fsensor.util.rotation.RotationUtil;
 public class ComplementaryGyroscopeSensor implements FSensor {
     private static final String TAG = ComplementaryGyroscopeSensor.class.getSimpleName();
 
-    private SensorManager sensorManager;
-    private SimpleSensorListener listener;
+    private final SensorManager sensorManager;
+    private final SimpleSensorListener listener;
     private float startTime = 0;
     private int count = 0;
 
@@ -45,7 +45,7 @@ public class ComplementaryGyroscopeSensor implements FSensor {
     private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
     private int sensorType = Sensor.TYPE_GYROSCOPE;
 
-    private SensorSubject sensorSubject;
+    private final SensorSubject sensorSubject;
 
     public ComplementaryGyroscopeSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/GyroscopeSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/GyroscopeSensor.java
@@ -31,8 +31,8 @@ public class GyroscopeSensor implements FSensor {
 
     private static final String TAG = GyroscopeSensor.class.getSimpleName();
 
-    private SensorManager sensorManager;
-    private SimpleSensorListener listener;
+    private final SensorManager sensorManager;
+    private final SimpleSensorListener listener;
     private float startTime = 0;
     private int count = 0;
 
@@ -46,7 +46,7 @@ public class GyroscopeSensor implements FSensor {
     private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
     private int sensorType = Sensor.TYPE_GYROSCOPE;
 
-    private SensorSubject sensorSubject;
+    private final SensorSubject sensorSubject;
 
     public GyroscopeSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/KalmanGyroscopeSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/KalmanGyroscopeSensor.java
@@ -7,10 +7,9 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 
 import com.kircherelectronics.fsensor.filter.gyroscope.fusion.kalman.OrientationFusedKalman;
+import com.kircherelectronics.fsensor.observer.SensorSubject;
 import com.kircherelectronics.fsensor.sensor.FSensor;
 import com.kircherelectronics.fsensor.util.rotation.RotationUtil;
-
-import io.reactivex.subjects.PublishSubject;
 
 /*
  * Copyright 2018, Kircher Electronics, LLC
@@ -36,9 +35,6 @@ public class KalmanGyroscopeSensor implements FSensor {
     private float startTime = 0;
     private int count = 0;
 
-    private boolean hasAcceleration = false;
-    private boolean hasMagnetic = false;
-
     private float[] magnetic = new float[3];
     private float[] acceleration = new float[3];
     private float[] rotation = new float[3];
@@ -46,47 +42,80 @@ public class KalmanGyroscopeSensor implements FSensor {
 
     private OrientationFusedKalman orientationFusionKalman;
 
-    private int sensorFrequency = SensorManager.SENSOR_DELAY_FASTEST;
+    private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
+    private int sensorType = Sensor.TYPE_GYROSCOPE;
 
-    private PublishSubject<float[]> publishSubject;
+    private SensorSubject sensorSubject;
 
     public KalmanGyroscopeSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
         this.listener = new SimpleSensorListener();
-        this.publishSubject = PublishSubject.create();
+        this.sensorSubject = new SensorSubject();
         initializeFSensorFusions();
     }
 
+    /**
+     * Start the sensor.
+     */
     @Override
-    public PublishSubject<float[]> getPublishSubject() {
-        return publishSubject;
-    }
-
-    public void onStart() {
+    public void start() {
         startTime = 0;
         count = 0;
-        registerSensors(sensorFrequency);
+        registerSensors(sensorDelay);
         orientationFusionKalman.startFusion();
     }
 
-    public void onStop() {
+    /**
+     * Stop the sensor.
+     */
+    @Override
+    public void stop() {
         orientationFusionKalman.stopFusion();
         unregisterSensors();
     }
 
-    public void setSensorFrequency(int sensorFrequency) {
-        this.sensorFrequency = sensorFrequency;
+    @Override
+    public void register(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.register(sensorObserver);
+    }
+
+    @Override
+    public void unregister(SensorSubject.SensorObserver sensorObserver) {
+        sensorSubject.unregister(sensorObserver);
+    }
+
+    /**
+     * Set the gyroscope sensor type.
+     * @param sensorType must be Sensor.TYPE_GYROSCOPE or Sensor.TYPE_GYROSCOPE_UNCALIBRATED
+     */
+    public void setSensorType(int sensorType) {
+        if(sensorType != Sensor.TYPE_GYROSCOPE && sensorType != Sensor.TYPE_GYROSCOPE_UNCALIBRATED) {
+            throw new IllegalStateException("Sensor Type must be Sensor.TYPE_GYROSCOPE or Sensor.TYPE_GYROSCOPE_UNCALIBRATED");
+        }
+
+        this.sensorType = sensorType;
+    }
+
+    /**
+     * Set the sensor frequency.
+     * @param sensorDelay Must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or SensorManager.SENSOR_DELAY_UI
+     */
+    public void setSensorDelay(int sensorDelay) {
+        if(sensorDelay != SensorManager.SENSOR_DELAY_FASTEST && sensorDelay != SensorManager.SENSOR_DELAY_GAME && sensorDelay != SensorManager.SENSOR_DELAY_NORMAL && sensorDelay != SensorManager.SENSOR_DELAY_UI) {
+            throw new IllegalStateException("Sensor Frequency must be SensorManager.SENSOR_DELAY_FASTEST, SensorManager.SENSOR_DELAY_GAME, SensorManager.SENSOR_DELAY_NORMAL or " +
+                    "SensorManager.SENSOR_DELAY_UI");
+        }
+        this.sensorDelay = sensorDelay;
     }
 
     public void reset() {
-        onStop();
+        stop();
         magnetic = new float[3];
         acceleration = new float[3];
         rotation = new float[3];
         output = new float[4];
-        hasAcceleration = false;
-        hasMagnetic = false;
-        onStart();
+        listener.reset();
+        start();
     }
 
     private float calculateSensorFrequency() {
@@ -138,7 +167,7 @@ public class KalmanGyroscopeSensor implements FSensor {
 
         // Register for sensor updates.
         sensorManager.registerListener(listener,
-                sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE_UNCALIBRATED),
+                sensorManager.getDefaultSensor(sensorType),
                 sensorDelay);
 
     }
@@ -150,10 +179,18 @@ public class KalmanGyroscopeSensor implements FSensor {
     private void setOutput(float[] value) {
         System.arraycopy(value, 0, output, 0, value.length);
         output[3] = calculateSensorFrequency();
-        publishSubject.onNext(output);
+        sensorSubject.onNext(output);
     }
 
     private class SimpleSensorListener implements SensorEventListener {
+
+        private boolean hasAcceleration = false;
+        private boolean hasMagnetic = false;
+
+        private void reset() {
+            hasAcceleration = false;
+            hasMagnetic = false;
+        }
 
         @Override
         public void onSensorChanged(SensorEvent event) {
@@ -163,7 +200,7 @@ public class KalmanGyroscopeSensor implements FSensor {
             } else if (event.sensor.getType() == Sensor.TYPE_MAGNETIC_FIELD) {
                 processMagnetic(event.values);
                 hasMagnetic = true;
-            } else if (event.sensor.getType() == Sensor.TYPE_GYROSCOPE_UNCALIBRATED) {
+            } else if (event.sensor.getType() == sensorType) {
                 processRotation(event.values);
 
                 if (!orientationFusionKalman.isBaseOrientationSet()) {

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/KalmanGyroscopeSensor.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/sensor/gyroscope/KalmanGyroscopeSensor.java
@@ -30,8 +30,8 @@ import com.kircherelectronics.fsensor.util.rotation.RotationUtil;
 public class KalmanGyroscopeSensor implements FSensor {
     private static final String TAG = KalmanGyroscopeSensor.class.getSimpleName();
 
-    private SensorManager sensorManager;
-    private SimpleSensorListener listener;
+    private final SensorManager sensorManager;
+    private final SimpleSensorListener listener;
     private float startTime = 0;
     private int count = 0;
 
@@ -45,7 +45,7 @@ public class KalmanGyroscopeSensor implements FSensor {
     private int sensorDelay = SensorManager.SENSOR_DELAY_FASTEST;
     private int sensorType = Sensor.TYPE_GYROSCOPE;
 
-    private SensorSubject sensorSubject;
+    private final SensorSubject sensorSubject;
 
     public KalmanGyroscopeSensor(Context context) {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/util/angle/AngleUtils.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/util/angle/AngleUtils.java
@@ -7,6 +7,9 @@ public class AngleUtils {
 
     /**
      * https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/index.htm
+     * https://developer.android.com/reference/android/hardware/SensorManager#getOrientation(float%5B%5D,%20float%5B%5D)
+     *
+     * The return format is the same as SensorManager.getOrientation()
      *
      * +X to the right
      * +Y straight up
@@ -19,6 +22,17 @@ public class AngleUtils {
      * Heading applied first
      * Attitude applied second
      * Bank applied last
+     *
+     * When it returns, the array values are as follows:
+     *
+     * values[0]: Azimuth, angle of rotation about the -z axis. This value represents the angle between the device's y axis and the magnetic north pole. When facing north, this
+     * angle is 0, when facing south, this angle is π. Likewise, when facing east, this angle is π/2, and when facing west, this angle is -π/2. The range of values is -π to π.
+     * values[1]: Pitch, angle of rotation about the x axis. This value represents the angle between a plane parallel to the device's screen and a plane parallel to the ground.
+     * Assuming that the bottom edge of the device faces the user and that the screen is face-up, tilting the top edge of the device toward the ground creates a positive pitch
+     * angle. The range of values is -π to π.
+     * values[2]: Roll, angle of rotation about the y axis. This value represents the angle between a plane perpendicular to the device's screen and a plane perpendicular to the
+     * ground. Assuming that the bottom edge of the device faces the user and that the screen is face-up, tilting the left edge of the device toward the ground creates a
+     * positive roll angle. The range of values is -π/2 to π/2.
      *
      * @param w
      * @param z
@@ -49,10 +63,10 @@ public class AngleUtils {
         double sqx = x*x;
         double sqy = y*y;
         double sqz = z*z;
-        heading = Math.atan2(2*y*w-2*x*z , 1 - 2*sqy - 2*sqz);
+        heading = -Math.atan2(2*y*w-2*x*z , 1 - 2*sqy - 2*sqz);
         pitch = -Math.asin(2*test);
         roll = -Math.atan2(2*x*w-2*y*z , 1 - 2*sqx - 2*sqz);
 
-        return new float[]{(float)pitch,(float)roll, (float)heading};
+        return new float[]{(float) heading, (float) pitch, (float) roll};
     }
 }

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/util/gravity/GravityUtil.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/util/gravity/GravityUtil.java
@@ -1,9 +1,6 @@
 package com.kircherelectronics.fsensor.util.gravity;
 
 import android.hardware.SensorManager;
-import android.util.Log;
-
-import java.util.Arrays;
 
 /*
  * Copyright 2018, Kircher Electronics, LLC

--- a/fsensor/src/main/java/com/kircherelectronics/fsensor/util/offset/FitPoints.java
+++ b/fsensor/src/main/java/com/kircherelectronics/fsensor/util/offset/FitPoints.java
@@ -162,9 +162,7 @@ public class FitPoints {
         RealMatrix dtdi = solver.getInverse();
 
         // v = (( d' * d )^-1) * ( d' * ones.mapAddToSelf(1));
-        RealVector v = dtdi.operate(dtOnes);
-
-        return v;
+        return dtdi.operate(dtOnes);
     }
 
     /**
@@ -245,9 +243,7 @@ public class FitPoints {
         t.setSubMatrix(centerMatrix.getData(), 3, 0);
 
         // Translate to the offset.
-        RealMatrix r = t.multiply(a).multiply(t.transpose());
-
-        return r;
+        return t.multiply(a).multiply(t.transpose());
     }
 
     /**


### PR DESCRIPTION
* For the sensor fusions, convert the rotation matrix from the accelerometer and magnetic sensors directly to a normalized quaternion instead of using Euler angles as an intermediary. This resolves a number of corner case bugs.
* Change the final output format to match SensorManager.getOrientation()
* Remove RxJava